### PR TITLE
Add CVE-2020-26256

### DIFF
--- a/CVEs/CVE-2020-26256.json
+++ b/CVEs/CVE-2020-26256.json
@@ -1,0 +1,24 @@
+{
+    "CVE": "CVE-2020-26256",
+    "state": "PUBLISHED",
+    "repository": "https://github.com/C2FO/fast-csv.git",
+    "prePatch": {
+        "commit": "b03b546f2ba55761bef96e43f78801fa342436d3",
+        "weaknesses": [
+            {
+                "location": {
+                    "file": "packages/parse/src/parser/Parser.ts",
+                    "line": 7
+                },
+                "explanation": "Inefficient regular expression"
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "4bbd39f26a8cd7382151ab4f5fb102234b2f829e"
+    },
+    "CWEs": [
+        "CWE-730",
+        "CWE-400"
+    ]
+}

--- a/CVEs/CVE-2020-26256.json
+++ b/CVEs/CVE-2020-26256.json
@@ -3,14 +3,14 @@
     "state": "PUBLISHED",
     "repository": "https://github.com/C2FO/fast-csv.git",
     "prePatch": {
-        "commit": "b03b546f2ba55761bef96e43f78801fa342436d3",
+        "commit": "1d18b894236687a5865ea70647010c1697a61d6d",
         "weaknesses": [
             {
                 "location": {
                     "file": "packages/parse/src/parser/Parser.ts",
                     "line": 7
                 },
-                "explanation": "Inefficient regular expression"
+                "explanation": "Inefficient regular expression for strings containing many repetitions of ' ,'."
             }
         ]
     },


### PR DESCRIPTION
GitHub advisory: https://github.com/advisories/GHSA-8cv5-p934-3hwp   
nist.gov: https://nvd.nist.gov/vuln/detail/CVE-2020-26256