### PR TITLE
add config.json sample to the README.md example (#4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,23 @@ $ bin/cli run --tool eslint-default CVE-2018-16492 CVE-2020-4066
 ```
 
 where `eslint-default` is the name of the driver configured for ESLint
-analysis.
+analysis in the `config.json` file:
+
+```json
+{
+  "tools": {
+    "eslint-default": {
+      "bin": "node",
+      "args": [
+        "/home/user-name/ossf-cve-benchmark/build/ts/contrib/tools/eslint/src/eslint.js",
+      ],
+      "options": {
+        "eslintDir": "/home/user-name/analysis-tools/eslint-2020-12-08"
+      }
+    }
+  }
+}
+```
 
 To run ESLint against all CVEs in the dataset, you can run:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,5 +83,85 @@ see [Configuring the driver for
 browse the README.md files of each driver in
 [contrib/tools](../contrib/tools).
 
+## Sample configuration files
+
+This section contains various `config.json` examples.
+
 For more information about the allowed contents of a configuration file, 
 see the JSON schema for the [Config](json-schema/ts-defs-definitions-config.md) type.
+
+### Minimal configuration file
+
+The configuration file does not need to specify anything, but if
+`config.json` is present, it should at least be a valid JSON object.
+
+```json
+{}
+```
+
+### Configuration file with one configured driver
+
+As mentioned above, the `.tools` property of the configuration file is
+used to configure drivers for analysis tools. The sample below makes
+it possible to use `bin/cli run --tool eslint-default` to benchmark
+ESLint.
+
+```json
+{
+  "tools": {
+    "eslint-default": {
+      "bin": "node",
+      "args": [
+        "/home/user-name/ossf-cve-benchmark/build/ts/contrib/tools/eslint/src/eslint.js",
+      ],
+      "options": {
+        "eslintDir": "/home/user-name/analysis-tools/eslint-2020-12-08"
+      }
+    }
+  }
+}
+```
+
+### Configuration file with two configured drivers
+
+It is rarely useful to only have one configured driver for
+benchmarking. The sample below makes it possible to use `bin/cli run
+--tool eslint-default --tool eslint-2019` to benchmark two different
+versions of ESLint.
+
+```json
+{
+  "tools": {
+    "eslint-default": {
+      "bin": "node",
+      "args": [
+        "/home/user-name/ossf-cve-benchmark/build/ts/contrib/tools/eslint/src/eslint.js",
+      ],
+      "options": {
+        "eslintDir": "/home/user-name/analysis-tools/eslint-2020-12-08"
+      }
+    },
+    "eslint-2019": {
+      "bin": "node",
+      "args": [
+        "/home/user-name/ossf-cve-benchmark/build/ts/contrib/tools/eslint/src/eslint.js",
+      ],
+      "options": {
+        "eslintDir": "/home/user-name/analysis-tools/eslint-2019-12-08"
+      }
+    }
+
+  }
+}
+```
+
+### Configuration file with custom download and result locations
+
+The `.sources` property of the configuration file controls the
+location that the relevant commits of CVEs are downloaded to.
+
+```json
+{
+  "sources": "/home/user-name/ossf-sources"
+}
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,9 +102,9 @@ The configuration file does not need to specify anything, but if
 ### Configuration file with one configured driver
 
 As mentioned above, the `.tools` property of the configuration file is
-used to configure drivers for analysis tools. The sample below makes
-it possible to use `bin/cli run --tool eslint-default` to benchmark
-ESLint.
+used to configure drivers for analysis tools. The example below configures 
+a driver for ESLint. You can then benchmark ESLint by running 
+`bin/cli run --tool eslint-default`.
 
 ```json
 {
@@ -125,9 +125,9 @@ ESLint.
 ### Configuration file with two configured drivers
 
 It is rarely useful to only have one configured driver for
-benchmarking. The sample below makes it possible to use `bin/cli run
---tool eslint-default --tool eslint-2019` to benchmark two different
-versions of ESLint.
+benchmarking. The sample below configures drivers for two different
+versions of ESLint. You can benchmark both versions to compare their performance
+by running `bin/cli run --tool eslint-default --tool eslint-2019`.
 
 ```json
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,7 +76,7 @@ value in `config.json`, you can specify `--sources` on the command line.
 
 ## Configuring drivers for analysis tools
 
-Configuration files are also used to to configure drivers for analysis
+Configuration files are also used to configure drivers for analysis
 tools.  For an example of configuring a driver for an analysis tool,
 see [Configuring the driver for
 `eslint`](eslint-example.md#configuring-the-driver-for-eslint), or


### PR DESCRIPTION
Adds a config.json sample to the README.md example, as suggested by #4.