### PR TITLE
Improve handling and messaging for incomplete or wrong configuration files

### DIFF
--- a/src/cli-commands/run.ts
+++ b/src/cli-commands/run.ts
@@ -42,13 +42,19 @@ export default async (
     non_fatal_validation_errors: boolean;
   }
 ) => {
-  let docReference = `Register tools by adding them to the tools section of the configuration file.
+  if (!config["config-file"] || config.tools === undefined) {
+    throw new UserError(
+      `This command requires a configuration file (config.json) with a '.tools' object.
+See docs/configuration.md and docs/analysis-tools.md for details.`
+    );
+  }
+
+  let docReference = `Register tools by adding them to the '.tools' object of the configuration file.
 See "docs/analysis-tools.md" for details.`;
 
-  if (config.tools === undefined || Object.keys(config.tools).length === 0) {
+  if (Object.keys(config.tools).length === 0) {
     throw new UserError(
       `No tools registered in the configuration file: can not run anything.
-
 ${docReference}`
     );
   }

--- a/src/cli-commands/tools.ts
+++ b/src/cli-commands/tools.ts
@@ -7,7 +7,7 @@ export default async (config: Config) => {
   if (!config["config-file"]) {
     console.warn(
       `This command works best when with a configuration file (config.json).
-See docs/configuration.md for details.`
+See docs/configuration.md and docs/analysis-tools.md for details.`
     );
   }
 

--- a/src/cli-commands/tools.ts
+++ b/src/cli-commands/tools.ts
@@ -4,6 +4,13 @@ import { getToolsRoot } from "../util";
 import { Config } from "../persistent-types";
 
 export default async (config: Config) => {
+  if (!config["config-file"]) {
+    console.warn(
+      `This command works best when with a configuration file (config.json).
+See docs/configuration.md for details.`
+    );
+  }
+
   let toolsRoot = getToolsRoot();
   let configured = config.tools ? Object.keys(config.tools) : [],
     readmes = fs

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,7 +47,6 @@ function main() {
     command: string;
   } = parser.parse_args();
   let { command, ...options } = args;
-  let config = getConfig(options);
 
   let commandFunction;
   for (let [k, v] of commands.entries()) {
@@ -61,6 +60,7 @@ function main() {
     process.exit(1);
   }
 
+  let config = getConfig(options);
   commandFunction(config, args)
     .then(() => process.exit(0))
     .catch((e: Error) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,8 @@
 import * as fs from "fs";
 import * as path from "path";
 import { Config, Dir, File } from "./persistent-types";
-import { checkUserProvidedFile, readConfigFile } from "./util";
+import { checkUserProvidedFile, readJSONFile, UserError } from "./util";
+import { getSchemaID, makeValidator, SchemaName } from "./validation";
 
 function getDefaultConfig(root: Dir): Config {
   return {
@@ -24,6 +25,29 @@ export type ConfigArgs = {
   reports?: Dir;
   export?: File;
 };
+
+/**
+ * Reads and returns the configuration file at `file`, immediately printing any validation errors as a warning.
+ */
+function readConfigFile(file: File): Config {
+  let config = readJSONFile(file),
+    validator = makeValidator(true),
+    valid = validator.validate(getSchemaID(SchemaName.Config), config);
+
+  if (!valid) {
+    let lines = [
+      `Configuration file ${file} is not valid, unexpected errors may occur when using this configuration file.`,
+      "",
+      ...validator.errors.map(e => `- ${JSON.stringify(e)}`),
+      "",
+      "See docs/configuration.md for details."
+    ].map(l => `Warning: ${l}`);
+    console.warn(lines.join("\n"));
+  }
+
+  return config;
+}
+
 export const DEFAULT_TIMEOUT = 30 * 60 * 1000;
 export function getConfig(args: ConfigArgs): Config {
   let implicitConfigFile = path.resolve("config.json");
@@ -41,7 +65,7 @@ export function getConfig(args: ConfigArgs): Config {
   let defaultConfig = getDefaultConfig(defaultConfigFile);
 
   let providedConfig: Config = configFile
-      ? readConfigFile(configFile, false)
+      ? readConfigFile(configFile)
       : undefined,
     baseConfig: Config = { ...defaultConfig, ...providedConfig },
     fullConfig: Config = {
@@ -64,7 +88,9 @@ export function getConfig(args: ConfigArgs): Config {
       if (k === "viewerRepo" || k === "config-file") {
         return;
       }
-      throw new Error(`Invalid config value for ${k}: ${JSON.stringify(v)}`);
+      throw new UserError(
+        `Invalid config value for ${k}: ${JSON.stringify(v)}`
+      );
     }
   });
   return fullConfig;

--- a/src/util.ts
+++ b/src/util.ts
@@ -249,17 +249,6 @@ export function readLogFile(
   );
 }
 
-export function readConfigFile(
-  file: File,
-  validationErrorsAreFatal: boolean
-): Config {
-  return readAndValidate(
-    file,
-    validation.SchemaName.Config,
-    validationErrorsAreFatal
-  );
-}
-
 function readAndValidate<T>(
   file: File,
   schemaName: validation.SchemaName,

--- a/src/util.ts
+++ b/src/util.ts
@@ -21,16 +21,34 @@ import {
 } from "./persistent-types";
 import * as validation from "./validation";
 
+/**
+ * @returns the root directory of this project.
+ */
 export function getProjectRoot(): Dir {
+  let root;
   if (__filename.endsWith("/util.ts")) {
     // happens during testing with jest
-    return path.resolve(path.join(__dirname, ".."));
+    root = path.resolve(path.join(__dirname, ".."));
+  } else {
+    root = path.resolve(path.join(__dirname, "..", "..", ".."));
   }
-  return path.resolve(path.join(__dirname, "..", "..", ".."));
+  if (!fs.existsSync(root)) {
+    throw new Error(`Could the project directory does not exist?! (${root})`);
+  }
+  return root;
 }
 
+/**
+ * @returns the tools/contrib directory of this project.
+ */
 export function getToolsRoot(): Dir {
-  return path.resolve(path.join(getProjectRoot(), "contrib", "tools"));
+  let root = path.resolve(path.join(getProjectRoot(), "contrib", "tools"));
+  if (!fs.existsSync(root)) {
+    throw new Error(
+      `Could the contrib/tools directory does not exist?! (${root})`
+    );
+  }
+  return root;
 }
 
 export function readJSONFile<T>(file: File): T {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -40,12 +40,12 @@ export function getSchemaID(schema: SchemaName): string {
 /**
  * @return a JSON schema validator for the persistent types of this project.
  */
-export function makeValidator(): Ajv.Ajv {
+export function makeValidator(allErrors = false): Ajv.Ajv {
   let validator = new Ajv({
     schemas: [...Object.keys(SchemaName), "ts-defs"].map(name =>
       readJSONFile(getSchema(name as any).file)
     ),
-    allErrors: false
+    allErrors: allErrors
   });
   return validator;
 }


### PR DESCRIPTION
Inspired by #4 and #5. 

If no configuration file is provided or present. The `tools` command will warn and point to the documentation.

```
$ bin/cli tools
This command works best when with a configuration file (config.json). 
See docs/configuration.md for details.
...
```

If no configuration file is provided or present. The `run` command will produce a more informative error message and point to the documentation.
```
$ bin/cli run --tool x x
User error: This command requires a configuration file (config.json) with a '.tools' object.
See docs/configuration.md and docs/analysis-tools.md for details.
```

Also explains the invalid configuration files slightly better, although JSON Schema validation errors are not the friendliest:


```json
{
  "my-weird-config.json-property": 42
}
```
```
$ bin/cli tools
Warning: Configuration file /home/esben/_data/ossf-cve-benchmarking/config.json is not valid, unexpected errors may occur when using this configuration file.
Warning: 
Warning: - {"keyword":"additionalProperties","dataPath":"","schemaPath":"#/additionalProperties","params":{"additionalProperty":"my-weird-config.json-property"},"message":"should NOT have additional properties"}
Warning: 
Warning: See docs/configuration.md for details.

```