### PR TITLE
Add sanity checks to install scripts

### DIFF
--- a/contrib/tools/codeql/installers/install.sh
+++ b/contrib/tools/codeql/installers/install.sh
@@ -25,6 +25,16 @@ NAME=codeql-bundle.tar.gz
 curl -LO "https://github.com/github/codeql-action/releases/latest/download/${NAME}"
 tar xvf "${NAME}" -C "${INSTALL_DIR}" > /dev/null
 
+BIN="${INSTALL_DIR}/codeql/codeql"
+if [ ! -f "${BIN}" ]; then
+    echo "ERROR: The download and extraction of codeql completed successfully, but ${BIN} does not exist?!">&2
+    exit 1
+fi
+if [ ! -x "${BIN}" ]; then
+    echo "ERROR: The download and extraction of codeql completed successfully, but ${BIN} is not executable?! ">&2
+    exit 1
+fi
+
 MAIN="${MYDIR}/../../../../build/ts/contrib/tools/codeql/src/codeql.js"
 MAIN=$(abspath "$MAIN")
 echo "The codeql tool has been installed. Add the fragment below to a config.json file:
@@ -40,7 +50,7 @@ echo "The codeql tool has been installed. Add the fragment below to a config.jso
                 \"${MAIN}\"
             ],
             \"options\": {
-              \"codeql\": \"${INSTALL_DIR}/codeql/codeql\"
+              \"codeql\": \"${BIN}\"
             }
 
         }

--- a/contrib/tools/eslint/installers/install.sh
+++ b/contrib/tools/eslint/installers/install.sh
@@ -21,6 +21,16 @@ cd "$INSTALL_DIR"
 npm init -y > /dev/null
 npm install eslint eslint-plugin-security eslint-plugin-security-node > /dev/null
 
+BIN="${INSTALL_DIR}/node_modules/eslint/bin/eslint.js"
+if [ ! -f "${BIN}" ]; then
+    echo "ERROR: The installation of eslint completed successfully, but ${BIN} does not exist?!">&2
+    exit 1
+fi
+if [ ! -x "${BIN}" ]; then
+    echo "ERROR: The installation of eslint completed successfully, but ${BIN} is not executable?! ">&2
+    exit 1
+fi
+
 MAIN="${MYDIR}/../../../../build/ts/contrib/tools/eslint/src/eslint.js"
 MAIN=$(abspath "$MAIN")
 echo "The eslint tool has been installed. Add the fragment below to a config.json file:

--- a/contrib/tools/nodejsscan/installers/install.sh
+++ b/contrib/tools/nodejsscan/installers/install.sh
@@ -19,6 +19,16 @@ INSTALL_DIR=$(abspath "$INSTALL_DIR")
 mkdir -p "$INSTALL_DIR"
 pip3 install -t "${INSTALL_DIR}" njsscan
 
+BIN="${INSTALL_DIR}/bin/njsscan"
+if [ ! -f "${BIN}" ]; then
+    echo "ERROR: The installation of njsscan completed successfully, but ${BIN} does not exist?!">&2
+    exit 1
+fi
+if [ ! -x "${BIN}" ]; then
+    echo "ERROR: The installation of njsscan completed successfully, but ${BIN} is not executable?! ">&2
+    exit 1
+fi
+
 MAIN="${MYDIR}/../../../../build/ts/contrib/tools/nodejsscan/src/nodejsscan.js"
 MAIN=$(abspath "$MAIN")
 echo "The njsscan tool has been installed. Add the fragment below to a config.json file:
@@ -28,7 +38,7 @@ echo "The njsscan tool has been installed. Add the fragment below to a config.js
   \"tools\": {
     ...
 
-    \"njsscan-default\": {
+    \"nodejsscan-default\": {
       \"bin\": \"node\",
       \"args\": [ \"${MAIN}\" ],
       \"options\": {


### PR DESCRIPTION
Inspired by #8: adds some checks for "does the executable exist?" and "is the executable executable?" to the install scripts. 
It is a bit more helpful to diagnose such problems during installation rather than during a `bin/cli run`.

I also ran the big integration test for this PR on my own fork: https://github.com/esbena/ossf-cve-benchmark/actions/runs/426621663