### PR TITLE
Introduce and use execFileSyncWithImprovedExceptionMessage

### DIFF
--- a/contrib/tools/codeql/src/codeql.ts
+++ b/contrib/tools/codeql/src/codeql.ts
@@ -3,13 +3,13 @@
  * See ../README.md for how to use this driver.
  */
 
-import * as cp from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import * as sarif from "sarif";
 import {
   AnalyzeParams,
   drive,
+  execFileSyncWithImprovedExceptionMessage,
   getDriverCommandlineInputs,
   simpleSpawn
 } from "../../../../src/driver";
@@ -42,13 +42,13 @@ function getMetaData(query: File, codeql: File): CodeQLMetaData {
     metadataCache.set(
       query,
       JSON.parse(
-        cp.execFileSync(codeql, [
+        execFileSyncWithImprovedExceptionMessage(codeql, [
           "resolve",
           "metadata",
           "--format",
           "json",
           query
-        ])
+        ]).toString()
       )
     );
   }
@@ -153,13 +153,13 @@ function getRelevantQueries(
 ): { language: string; files: File[] } {
   let language = "javascript", // TODO de-hardcode this
     packs = JSON.parse(
-      cp.execFileSync(options.codeql, [
+      execFileSyncWithImprovedExceptionMessage(options.codeql, [
         "resolve",
         "qlpacks",
         ...(options.searchPath ? ["--search-path", options.searchPath] : []),
         "--format",
         "json"
-      ])
+      ]).toString()
     ),
     pack: Dir = packs[`codeql-${language}`]?.[0];
   if (pack === undefined) {
@@ -201,7 +201,7 @@ function analyzeWithDriver(
     setStatus
   }: AnalyzeParams) {
     // check if `codeql` works as expected
-    cp.execFileSync(options.codeql, ["--help"]);
+    execFileSyncWithImprovedExceptionMessage(options.codeql, ["--help"]);
 
     let logdir = path.join(tmp, "logs"),
       queries = getRelevantQueries(bcve, options),

--- a/contrib/tools/eslint/src/eslint.ts
+++ b/contrib/tools/eslint/src/eslint.ts
@@ -5,13 +5,13 @@
  * This driver is the reference driver for the CVE Benchmarker.
  */
 
-import * as cp from "child_process";
 import * as fs from "fs-extra";
 import * as path from "path";
 import {
   Analyze,
   AnalyzeParams,
   drive,
+  execFileSyncWithImprovedExceptionMessage,
   getDriverCommandlineInputs,
   simpleSpawn
 } from "../../../../src/driver";
@@ -68,7 +68,7 @@ function makeAnalyzeFunction(eslintDir: Dir, timeout: number): Analyze {
     );
 
     // check if `eslint` works as expected
-    cp.execFileSync(eslint, ["--help"]);
+    execFileSyncWithImprovedExceptionMessage(eslint, ["--help"]);
 
     let tmpEslintDir = path.join(tmp, "eslint");
     // XXX this is a terrible hack to make the plugins be resolved appropriately wrt. the provided config file!

--- a/contrib/tools/nodejsscan/src/nodejsscan.ts
+++ b/contrib/tools/nodejsscan/src/nodejsscan.ts
@@ -1,8 +1,8 @@
-import * as cp from "child_process";
 import * as path from "path";
 import {
   AnalyzeParams,
   drive,
+  execFileSyncWithImprovedExceptionMessage,
   getDriverCommandlineInputs,
   simpleSpawn
 } from "../../../../src/driver";
@@ -31,7 +31,7 @@ function analyzeWithDriver(njsscanDir: Dir, timeout: number): Promise<void> {
       };
 
     // check if `njsscan` works as expected
-    cp.execFileSync(njsscan, ["--help"], { env });
+    execFileSyncWithImprovedExceptionMessage(njsscan, ["--help"], { env });
 
     let sarifFile: File = path.join(tmp, "results.sarif"),
       args: string[] = [

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -70,6 +70,24 @@ type DriverState = {
 };
 
 /**
+ * A simple wrapper around `child_process.execFileSync` that adds additional details to the  exception message, if any.
+ */
+export function execFileSyncWithImprovedExceptionMessage(
+  bin: File,
+  args?: ReadonlyArray<string>,
+  options?: cp.ExecFileSyncOptions | cp.ExecFileSyncOptionsWithBufferEncoding
+) {
+  try {
+    return cp.execFileSync(bin, args, options);
+  } catch (e) {
+    let msg = `Failed to execute child-process in ${
+      options.cwd ? options.cwd : path.resolve(".")
+    }: '${bin} ${args.join(" ")}': ${e.message || JSON.stringify(e)}`;
+    throw new Error(msg);
+  }
+}
+
+/**
  * A simple wrapper around `child_process.spawn` that suits the needs of most drivers.
  *
  * Process errors or timeouts causes the promise to be rejected with an error message.
@@ -81,6 +99,7 @@ type DriverState = {
  * @param cwd the working directory of the spawned process
  * @param timeout the time (ms) the spawned process is allowed to run
  * @param setStatus a callback that can be used to set the (TIMEOUT) status for the run
+ * @param env the environment varaibles to use
  */
 export async function simpleSpawn(
   bin: File,

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -81,7 +81,7 @@ export function execFileSyncWithImprovedExceptionMessage(
     return cp.execFileSync(bin, args, options);
   } catch (e) {
     let msg = `Failed to execute child-process in ${
-      options.cwd ? options.cwd : path.resolve(".")
+      options && options.cwd ? options.cwd : path.resolve(".")
     }: '${bin} ${args ? args.join(" ") : ""}': ${e.message || JSON.stringify(e)}`;
     throw new Error(msg);
   }

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -82,7 +82,7 @@ export function execFileSyncWithImprovedExceptionMessage(
   } catch (e) {
     let msg = `Failed to execute child-process in ${
       options.cwd ? options.cwd : path.resolve(".")
-    }: '${bin} ${args.join(" ")}': ${e.message || JSON.stringify(e)}`;
+    }: '${bin} ${args ? args.join(" ") : ""}': ${e.message || JSON.stringify(e)}`;
     throw new Error(msg);
   }
 }

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -82,7 +82,9 @@ export function execFileSyncWithImprovedExceptionMessage(
   } catch (e) {
     let msg = `Failed to execute child-process in ${
       options && options.cwd ? options.cwd : path.resolve(".")
-    }: '${bin} ${args ? args.join(" ") : ""}': ${e.message || JSON.stringify(e)}`;
+    }: '${bin} ${args ? args.join(" ") : ""}': ${
+      e.message || JSON.stringify(e)
+    }`;
     throw new Error(msg);
   }
 }


### PR DESCRIPTION
Makes the `execFileSync` usages emit more detailed error messages such that #12 would have been easier to diagnose.

