### PR TITLE
Reuse the `node` executable of the parent process

### DIFF
--- a/contrib/tools/eslint/src/eslint.ts
+++ b/contrib/tools/eslint/src/eslint.ts
@@ -60,15 +60,17 @@ function makeAnalyzeFunction(eslintDir: Dir, timeout: number): Analyze {
     // STEP 1: preparations for the run
     let eslintConfig = getESLintConfig(bcve.CVE);
     let eslint = path.join(
-      eslintDir,
-      "node_modules",
-      "eslint",
-      "bin",
-      "eslint.js"
-    );
+        eslintDir,
+        "node_modules",
+        "eslint",
+        "bin",
+        "eslint.js"
+      ),
+      // avoid relying on the `#!/usr/bin/env node` of eslint.js: explicitly reuse the parent `node` executable
+      node = process.argv[0];
 
     // check if `eslint` works as expected
-    execFileSyncWithImprovedExceptionMessage(eslint, ["--help"]);
+    execFileSyncWithImprovedExceptionMessage(node, [eslint, "--help"]);
 
     let tmpEslintDir = path.join(tmp, "eslint");
     // XXX this is a terrible hack to make the plugins be resolved appropriately wrt. the provided config file!
@@ -78,6 +80,7 @@ function makeAnalyzeFunction(eslintDir: Dir, timeout: number): Analyze {
 
     let outputFile: File = path.join(tmp, "output.json"),
       args: string[] = [
+        eslint,
         "--no-inline-config",
         "--no-eslintrc",
         "--config",
@@ -93,11 +96,11 @@ function makeAnalyzeFunction(eslintDir: Dir, timeout: number): Analyze {
     setReproduction(`# navigate to project
 cd ${tmp}
 # run eslint
-${eslint} ${args.join(" ")}`);
+${node} ${args.join(" ")}`);
 
     // STEP 2: run eslint
     try {
-      await simpleSpawn(eslint, args, tmp, timeout, setStatus);
+      await simpleSpawn(node, args, tmp, timeout, setStatus);
     } catch (e) {
       if (e.code !== 1) {
         throw e;


### PR DESCRIPTION
The `eslint/node_modules/bin/eslint.js` file contains the following:

```javascript
#!/usr/bin/env node
```

This is convenient in general, but may lead to confusing errors when the user specifies a different `node` explicitly in config.json, (especially since windows ignores the `#!` line entirely):

```json
    "eslint-default": {
      "bin": "/home/user/.nvm/versions/node/v14.15.0/bin/node",
      ....
```

