### PR TITLE
Replace bad %40 with correct @ in CVE-2020-8135

### DIFF
--- a/CVEs/CVE-2020-8135.json
+++ b/CVEs/CVE-2020-8135.json
@@ -7,7 +7,7 @@
         "weaknesses": [
             {
                 "location": {
-                    "file": "packages/%40uppy/companion/src/server/helpers/utils.js",
+                    "file": "packages/@uppy/companion/src/server/helpers/utils.js",
                     "line": 73
                 },
                 "explanation": "Server-side URL redirect"


### PR DESCRIPTION
Closes #146.

The `@uppy` path is correctly represented in a similar CVE: https://github.com/ossf-cve-benchmark/ossf-cve-benchmark/blob/c6835893ad975a38841df35d5d0e5e5b5296669a/CVEs/CVE-2020-8205.json#L10