### PR TITLE
improve Checks.yml: use npx and npm ci more

### DIFF
--- a/.github/workflows/Checks.yml
+++ b/.github/workflows/Checks.yml
@@ -49,7 +49,7 @@ jobs:
     - uses: actions/checkout@v2
     - run: |
         npm ci
-        tsc
+        npx tsc
         bin/cli validate --schema BCVE CVEs
 
   formatting:
@@ -61,5 +61,5 @@ jobs:
         node-version: 12
     - uses: actions/checkout@v2
     - run: |
-        npm i prettier # no need to install the entire project here
+        npm ci
         npx prettier -c .

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "eslint": "^7.18.0",
         "eslint-config-prettier": "^7.2.0",
         "jest": "^26.6.3",
+        "prettier": "^2.2.0",
         "source-map-loader": "^1.1.2",
         "style-loader": "^2.0.0",
         "ts-jest": "^26.4.4",
@@ -7628,6 +7629,18 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/pretty-format": {
@@ -16859,6 +16872,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint": "^7.18.0",
     "eslint-config-prettier": "^7.2.0",
     "jest": "^26.6.3",
+    "prettier": "^2.2.0",
     "source-map-loader": "^1.1.2",
     "style-loader": "^2.0.0",
     "ts-jest": "^26.4.4",


### PR DESCRIPTION
Makes use of `npm ci` to get consistent formatting rules. Should fix the test failures in https://github.com/ossf-cve-benchmark/ossf-cve-benchmark/pull/171, https://github.com/ossf-cve-benchmark/ossf-cve-benchmark/pull/176, https://github.com/ossf-cve-benchmark/ossf-cve-benchmark/pull/184.
Also: drive by fix for `tsc ---> npx tsc`.

Doh. The main culprit turned out to be a lack of prettier in package.json, and `npx prettier` installing the latest (incompatible version)