### PR TITLE
WIP: Add some CVEs from Android

### DIFF
--- a/CVEs/CVE-2015-3823.json
+++ b/CVEs/CVE-2015-3823.json
@@ -1,0 +1,20 @@
+{
+    "CVE": "CVE-2015-3823",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/frameworks/av",
+    "prePatch": {
+        "commit": "deba0610c89d54390c9d2d0a0f3b79fd7679779c",
+        "weaknesses": [
+            {
+                "file": "media/libstagefright/matroska/MatroskaExtractor.cpp",
+                "location": 566
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "407d475b797fdc595299d67151230dc6e3835ccd"
+    },
+    "CWEs": [
+        "CWE-119"
+    ]
+}

--- a/CVEs/CVE-2015-3824.json
+++ b/CVEs/CVE-2015-3824.json
@@ -1,0 +1,20 @@
+{
+    "CVE": "CVE-2015-3824",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/frameworks/av",
+    "prePatch": {
+        "commit": "f4a88c8ed4f8186b3d6e2852993e063fc33ff231",
+        "weaknesses": [
+            {
+                "file": "media/libstagefright/MPEG4Extractor.cpp",
+                "location": 1896
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "463a6f807e187828442949d1924e143cf07778c6"
+    },
+    "CWEs": [
+        "CWE-119"
+    ]
+}

--- a/CVEs/CVE-2015-3831.json
+++ b/CVEs/CVE-2015-3831.json
@@ -1,0 +1,20 @@
+{
+    "CVE": "CVE-2015-3831",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/frameworks/av",
+    "prePatch": {
+        "commit": "5e751957ba692658b7f67eb03ae5ddb2cd3d970c",
+        "weaknesses": [
+            {
+                "file": "media/libmedia/IMediaHTTPConnection.cpp",
+                "location": 112
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "51504928746edff6c94a1c498cf99c0a83bedaed"
+    },
+    "CWEs": [
+        "CWE-119"
+    ]
+}

--- a/CVEs/CVE-2015-3834.json
+++ b/CVEs/CVE-2015-3834.json
@@ -1,0 +1,24 @@
+{
+    "CVE": "CVE-2015-3834",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/frameworks/av",
+    "prePatch": {
+        "commit": "d48f0f145f8f0f4472bc0af668ac9a8bce44ba9b",
+        "weaknesses": [
+            {
+                "file": "media/libmedia/IHDCP.cpp",
+                "location": 245
+            },
+            {
+                "file": "media/libmedia/IHDCP.cpp",
+                "location": 299
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "c82e31a7039a03dca7b37c65b7890ba5c1e18ced"
+    },
+    "CWEs": [
+        "CWE-189"
+    ]
+}

--- a/CVEs/CVE-2015-3836.json
+++ b/CVEs/CVE-2015-3836.json
@@ -1,0 +1,20 @@
+{
+    "CVE": "CVE-2015-3836",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/external/sonivox",
+    "prePatch": {
+        "commit": "c0723d864b10fbd6c5cbbfa65e886c5e9eb3aafd",
+        "weaknesses": [
+            {
+                "file": "arm-wt-22k/lib_src/eas_mdls.c",
+                "location": 941
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "e999f077f6ef59d20282f1e04786816a31fb8be6"
+    },
+    "CWEs": [
+        "CWE-189"
+    ]
+}

--- a/CVEs/CVE-2015-3837.json
+++ b/CVEs/CVE-2015-3837.json
@@ -1,0 +1,20 @@
+{
+    "CVE": "CVE-2015-3837",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/external/conscrypt",
+    "prePatch": {
+        "commit": "feca781b5ad72ed1fe5688acc9eebee55e4601b1",
+        "weaknesses": [
+            {
+                "file": "src/main/java/org/conscrypt/OpenSSLX509Certificate.java",
+                "location": 55
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "edf7055461e2d7fa18de5196dca80896a56e3540"
+    },
+    "CWEs": [
+        "CWE-20"
+    ]
+}

--- a/CVEs/CVE-2015-3845.json
+++ b/CVEs/CVE-2015-3845.json
@@ -1,0 +1,20 @@
+{
+    "CVE": "CVE-2015-3845",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/frameworks/native",
+    "prePatch": {
+        "commit": "7dcd0ec9c91688cfa3f679804ba6e132f9811254",
+        "weaknesses": [
+            {
+                "file": "libs/binder/Parcel.cpp",
+                "location": 414
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "e68cbc3e9e66df4231e70efa3e9c41abc12aea20"
+    },
+    "CWEs": [
+        "CWE-264"
+    ]
+}

--- a/CVEs/CVE-2015-3858.json
+++ b/CVEs/CVE-2015-3858.json
@@ -1,0 +1,28 @@
+{
+    "CVE": "CVE-2015-3858",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/frameworks/opt/telephony",
+    "prePatch": {
+        "commit": "b48581401259439dc5ef6dcf8b0f303e4cbefbe9",
+        "weaknesses": [
+            {
+                "file": "src/java/com/android/internal/telephony/SMSDispatcher.java",
+                "location": 91
+            },
+            {
+                "file": "src/java/com/android/internal/telephony/SMSDispatcher.java",
+                "location": 92
+            },
+            {
+                "file": "src/java/com/android/internal/telephony/SMSDispatcher.java",
+                "location": 998
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "df31d37d285dde9911b699837c351aed2320b586"
+    },
+    "CWEs": [
+        "CWE-264"
+    ]
+}

--- a/CVEs/CVE-2015-3861.json
+++ b/CVEs/CVE-2015-3861.json
@@ -1,0 +1,24 @@
+{
+    "CVE": "CVE-2015-3861",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/frameworks/av",
+    "prePatch": {
+        "commit": "a5d9298a07d768552077cdbc5c1141e0e656485b",
+        "weaknesses": [
+            {
+                "file": "media/libstagefright/MetaData.cpp",
+                "location": 275
+            },
+            {
+                "file": "media/libstagefright/matroska/MatroskaExtractor.cpp",
+                "location": 897
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "304ef91624e12661e7e35c2c0c235da84a73e9c0"
+    },
+    "CWEs": [
+        "CWE-189"
+    ]
+}

--- a/CVEs/CVE-2015-3864.json
+++ b/CVEs/CVE-2015-3864.json
@@ -1,0 +1,20 @@
+{
+    "CVE": "CVE-2015-3864",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/frameworks/av",
+    "prePatch": {
+        "commit": "304ef91624e12661e7e35c2c0c235da84a73e9c0",
+        "weaknesses": [
+            {
+                "file": "media/libstagefright/MPEG4Extractor.cpp",
+                "location": 1896
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "6fe85f7e15203e48df2cc3e8e1c4bc6ad49dc968"
+    },
+    "CWEs": [
+        "CWE-189"
+    ]
+}

--- a/CVEs/CVE-2015-3867.json
+++ b/CVEs/CVE-2015-3867.json
@@ -1,0 +1,20 @@
+{
+    "CVE": "CVE-2015-3867",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/frameworks/av",
+    "prePatch": {
+        "commit": "3ce293842fed1b3abd2ff0aecd2a0c70a55086ee",
+        "weaknesses": [
+            {
+                "file": "media/libstagefright/MPEG4Extractor.cpp",
+                "location": 1775
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "7e9ac3509d72e8dc6f1316b5ce0a0066638b9737"
+    },
+    "CWEs": [
+        "CWE-119"
+    ]
+}

--- a/CVEs/CVE-2015-3868.json
+++ b/CVEs/CVE-2015-3868.json
@@ -1,0 +1,20 @@
+{
+    "CVE": "CVE-2015-3868",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/frameworks/av",
+    "prePatch": {
+        "commit": "916a9684295fb578f4b3c6c16b621ef201a49964",
+        "weaknesses": [
+            {
+                "file": "media/libstagefright/MPEG4Extractor.cpp",
+                "location": 2719
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "937c6bedd4b6e5c6cb29a238eb459047dedd3486"
+    },
+    "CWEs": [
+        "CWE-119"
+    ]
+}

--- a/CVEs/CVE-2015-3869.json
+++ b/CVEs/CVE-2015-3869.json
@@ -1,0 +1,32 @@
+{
+    "CVE": "CVE-2015-3869",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/frameworks/av",
+    "prePatch": {
+        "commit": "2e637bfd64c59200414130671e32e3e087e9f147",
+        "weaknesses": [
+            {
+                "file": "media/libstagefright/OggExtractor.cpp",
+                "location": 926
+            },
+            {
+                "file": "media/libstagefright/OggExtractor.cpp",
+                "location": 930
+            },
+            {
+                "file": "media/libstagefright/OggExtractor.cpp",
+                "location": 946
+            },
+            {
+                "file": "media/libstagefright/OggExtractor.cpp",
+                "location": 952
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "450e1015b7939292ca988dd1b4f0303a094478e9"
+    },
+    "CWEs": [
+        "CWE-119"
+    ]
+}

--- a/CVEs/CVE-2015-3871.json
+++ b/CVEs/CVE-2015-3871.json
@@ -1,0 +1,20 @@
+{
+    "CVE": "CVE-2015-3871",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/frameworks/av",
+    "prePatch": {
+        "commit": "171b5fadb9d304f5e06686e4f3d060ef335d7250",
+        "weaknesses": [
+            {
+                "file": "media/libstagefright/MPEG4Extractor.cpp",
+                "location": 2220
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "c570778430a22b5488cae72982cf9fb8033dbda3"
+    },
+    "CWEs": [
+        "CWE-119"
+    ]
+}

--- a/CVEs/CVE-2015-3876.json
+++ b/CVEs/CVE-2015-3876.json
@@ -1,0 +1,24 @@
+{
+    "CVE": "CVE-2015-3876",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/frameworks/av",
+    "prePatch": {
+        "commit": "916a9684295fb578f4b3c6c16b621ef201a49964",
+        "weaknesses": [
+            {
+                "file": "media/libstagefright/id3/ID3.cpp",
+                "location": 691
+            },
+            {
+                "file": "media/libstagefright/id3/ID3.cpp",
+                "location": 701
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "c580c836c1941fb4912e1dd4e08626caf98a62c7"
+    },
+    "CWEs": [
+        "CWE-20"
+    ]
+}

--- a/CVEs/CVE-2015-6601.json
+++ b/CVEs/CVE-2015-6601.json
@@ -1,0 +1,24 @@
+{
+    "CVE": "CVE-2015-6601",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/frameworks/av",
+    "prePatch": {
+        "commit": "4dd7cb699f49b56f94a32080fdac7f0ec8237ff4",
+        "weaknesses": [
+            {
+                "file": "media/libstagefright/SampleTable.cpp",
+                "location": 336
+            },
+            {
+                "file": "media/libstagefright/SampleTable.cpp",
+                "location": 382
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "738a753a3ca7bf8f9f608ca941575626265294e4"
+    },
+    "CWEs": [
+        "CWE-119"
+    ]
+}

--- a/CVEs/CVE-2015-6603.json
+++ b/CVEs/CVE-2015-6603.json
@@ -1,0 +1,20 @@
+{
+    "CVE": "CVE-2015-6603",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/frameworks/av",
+    "prePatch": {
+        "commit": "deba0610c89d54390c9d2d0a0f3b79fd7679779c",
+        "weaknesses": [
+            {
+                "file": "media/libstagefright/id3/ID3.cpp",
+                "location": 352
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "c37f7f6fa0cb7f55cdc5b2d4ccbf2c87c3bc6c3b"
+    },
+    "CWEs": [
+        "CWE-119"
+    ]
+}

--- a/CVEs/CVE-2015-6604.json
+++ b/CVEs/CVE-2015-6604.json
@@ -1,0 +1,24 @@
+{
+    "CVE": "CVE-2015-6604",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/frameworks/av",
+    "prePatch": {
+        "commit": "c86eae32ebb0cc580a13dde30fe765a96b8e701c",
+        "weaknesses": [
+            {
+                "file": "media/libstagefright/id3/ID3.cpp",
+                "location": 330
+            },
+            {
+                "file": "media/libstagefright/id3/ID3.cpp",
+                "location": 342
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "f51115bd8e44c2779b74477277c6f6046916e7cf"
+    },
+    "CWEs": [
+        "CWE-119"
+    ]
+}

--- a/CVEs/CVE-2015-6623.json
+++ b/CVEs/CVE-2015-6623.json
@@ -1,0 +1,28 @@
+{
+    "CVE": "CVE-2015-6623",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/frameworks/opt/net/wifi",
+    "prePatch": {
+        "commit": "4436f1f214d4831e4b3615b3f4fc96abf3ffa20a",
+        "weaknesses": [
+            {
+                "file": "service/java/com/android/server/wifi/WifiConfigStore.java",
+                "location": 395
+            },
+            {
+                "file": "service/java/com/android/server/wifi/WifiConfigStore.java",
+                "location": 396
+            },
+            {
+                "file": "service/java/com/android/server/wifi/WifiServiceImpl.java",
+                "location": 1916
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "a15a2ee69156fa6fff09c0dd9b8182cb8fafde1c"
+    },
+    "CWEs": [
+        "CWE-264"
+    ]
+}

--- a/CVEs/CVE-2015-6629.json
+++ b/CVEs/CVE-2015-6629.json
@@ -1,0 +1,32 @@
+{
+    "CVE": "CVE-2015-6629",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/frameworks/opt/net/wifi",
+    "prePatch": {
+        "commit": "88daa7e9d975b8b6674157dd6e81d358c7d16393",
+        "weaknesses": [
+            {
+                "file": "service/java/com/android/server/wifi/WifiNative.java",
+                "location": 145
+            },
+            {
+                "file": "service/java/com/android/server/wifi/WifiNative.java",
+                "location": 146
+            },
+            {
+                "file": "service/java/com/android/server/wifi/WifiNative.java",
+                "location": 150
+            },
+            {
+                "file": "service/java/com/android/server/wifi/WifiNative.java",
+                "location": 151
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "8b41627f7411306a0c42867fb526fa214f2991cd"
+    },
+    "CWEs": [
+        "CWE-200"
+    ]
+}

--- a/CVEs/CVE-2016-0809.json
+++ b/CVEs/CVE-2016-0809.json
@@ -1,0 +1,20 @@
+{
+    "CVE": "CVE-2016-0809",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/hardware/broadcom/wlan",
+    "prePatch": {
+        "commit": "06a2d34583130aa2c8d923f2f850dce1ffcf3349",
+        "weaknesses": [
+            {
+                "file": "bcmdhd/wifi_hal/wifi_hal.cpp",
+                "location": 339
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "2c5a4fac8bc8198f6a2635ede776f8de40a0c3e1"
+    },
+    "CWEs": [
+        "CWE-264"
+    ]
+}

--- a/CVEs/CVE-2016-2422.json
+++ b/CVEs/CVE-2016-2422.json
@@ -1,0 +1,20 @@
+{
+    "CVE": "CVE-2016-2422",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/packages/apps/CertInstaller",
+    "prePatch": {
+        "commit": "33c0a544f35937a5175e45dea1c71d37595c4d3f",
+        "weaknesses": [
+            {
+                "file": "src/com/android/certinstaller/CertInstaller.java",
+                "location": 183
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "70dde9870e9450e10418a32206ac1bb30f036b2c"
+    },
+    "CWEs": [
+        "CWE-264"
+    ]
+}

--- a/CVEs/CVE-2016-2439.json
+++ b/CVEs/CVE-2016-2439.json
@@ -1,0 +1,20 @@
+{
+    "CVE": "CVE-2016-2439",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/system/bt",
+    "prePatch": {
+        "commit": "3ddadd2c27e6a22e2d2b205e9ff73d13e0c35cc5",
+        "weaknesses": [
+            {
+                "file": "btif/src/btif_dm.c",
+                "location": 2439
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "9b534de2aca5d790c2a1c4d76b545f16137d95dd"
+    },
+    "CWEs": [
+        "CWE-119"
+    ]
+}

--- a/CVEs/CVE-2016-3744.json
+++ b/CVEs/CVE-2016-3744.json
@@ -1,0 +1,20 @@
+{
+    "CVE": "CVE-2016-3744",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/system/bt",
+    "prePatch": {
+        "commit": "37c88107679d36c419572732b4af6e18bb2f7dce",
+        "weaknesses": [
+            {
+                "file": "btif/src/btif_hh.c",
+                "location": 257
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "514139f4b40cbb035bb92f3e24d5a389d75db9e6"
+    },
+    "CWEs": [
+        "CWE-119"
+    ]
+}

--- a/CVEs/CVE-2016-3882.json
+++ b/CVEs/CVE-2016-3882.json
@@ -1,0 +1,24 @@
+{
+    "CVE": "CVE-2016-3882",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/frameworks/opt/net/wifi",
+    "prePatch": {
+        "commit": "c2905409c20c8692d4396b8531b09e7ec81fa3fb",
+        "weaknesses": [
+            {
+                "file": "service/java/com/android/server/wifi/anqp/VenueNameElement.java",
+                "location": 32
+            },
+            {
+                "file": "service/java/com/android/server/wifi/anqp/VenueNameElement.java",
+                "location": 38
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "35a86eef3c0eef760f7e61c52a343327ba601630"
+    },
+    "CWEs": [
+        "CWE-284"
+    ]
+}

--- a/CVEs/CVE-2017-0646.json
+++ b/CVEs/CVE-2017-0646.json
@@ -1,0 +1,24 @@
+{
+    "CVE": "CVE-2017-0646",
+    "state": "PUBLISHED",
+    "repository": "https://android.googlesource.com/platform/system/bt",
+    "prePatch": {
+        "commit": "a4875a49404c544134df37022ae587a4a3321647",
+        "weaknesses": [
+            {
+                "file": "stack/btm/btm_ble_gap.c",
+                "location": 2288
+            },
+            {
+                "file": "stack/btm/btm_ble_gap.c",
+                "location": 2543
+            }
+        ]
+    },
+    "postPatch": {
+        "commit": "2bcdf8ec7db12c5651c004601901f1fc25153f2c"
+    },
+    "CWEs": [
+        "CWE-200"
+    ]
+}


### PR DESCRIPTION
Following #206

The PR here add vulnerabilities from Android Open Source Project for both Java, C or C++ code.

I guess the following actions need to be done before merging:

- [ ]  support external sources for projects (e.g. not github)
- [ ] change the schema to allow an optional `explanation` field