### PR TITLE
Refactor Alert parsing

### DIFF
--- a/contrib/reports/explore-server/src/server/index.ts
+++ b/contrib/reports/explore-server/src/server/index.ts
@@ -226,13 +226,13 @@ export default class ExploreServer {
     let targets = this.targets,
       rulesOnATarget = this.rulesOnATarget;
 
-    function getAlerts(
-      commitDescription: CommitDescription
-    ): ClientTypes.Alert[] {
-      let alerts = (commitDescription.runs || []).flatMap(r =>
+    function addAlerts(
+      commitDescription: CommitDescription, alerts: ClientTypes.Alert[]
+    ): void {
+      (commitDescription.runs || []).forEach(r =>
         (r.alerts || [])
           .filter(a => !!a.location)
-          .map(a => ({
+          .forEach(a => alerts.push({
             CVE: bcve.CVE,
             commit: makeCommitData(
               bcve.CVE,
@@ -259,14 +259,13 @@ export default class ExploreServer {
             url: a.url
           }))
       );
-      return alerts;
     }
-    let alerts = [];
+    let alerts: ClientTypes.Alert[] = [];
     if (bcve.prePatch) {
-      alerts.push(...getAlerts(bcve.prePatch));
+      addAlerts(bcve.prePatch, alerts);
     }
     if (bcve.postPatch) {
-      alerts.push(...getAlerts(bcve.postPatch));
+      addAlerts(bcve.postPatch, alerts);
     }
     return alerts;
   }


### PR DESCRIPTION
I've tried to compare a lot's of data and ran into an issue when I got the following `RangeError: Maximum call stack size exceeded` error message:
![image](https://github.com/ossf-cve-benchmark/ossf-cve-benchmark/assets/17620914/192d92a6-82c5-45a3-a881-5e378b980d2b)

This change is fixing the aforementioned issue with some functional programming practices.

Passing an array as a parameter instead of returning a new array every time is reducing the amount of memory needed for this operation, and fixing the memory error.