### PR TITLE
feat: store multiple lines in one alert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,96 @@
 /node_modules
 /build
 /config.json
+
+# Created by https://www.toptal.com/developers/gitignore/api/intellij+all
+# Edit at https://www.toptal.com/developers/gitignore?templates=intellij+all
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+.idea/*
+
+!.idea/codeStyles
+!.idea/runConfigurations
+
+# End of https://www.toptal.com/developers/gitignore/api/intellij+all

--- a/contrib/reports/explore-server/src/client/CVEResultSummarization.tsx
+++ b/contrib/reports/explore-server/src/client/CVEResultSummarization.tsx
@@ -103,7 +103,7 @@ class OverviewTable extends React.Component<OverviewProps, OverviewState> {
                       a.toolID === t &&
                       row.commit.commitID === a.commit.commitID &&
                       row.file === a.file &&
-                      row.line === a.line
+                      a.lines.some(line => row.line === line)
                   )}
                   hasRun={(self.props.toolRuns[t] || []).includes(
                     this.props.unpatchedCommit.commitID
@@ -129,7 +129,7 @@ class OverviewTable extends React.Component<OverviewProps, OverviewState> {
             ta =>
               ta.toolID === t &&
               ta.isOnTarget &&
-              w.line === ta.line &&
+              ta.lines.some(line => w.line === line) &&
               w.file === ta.file
           ))
       );

--- a/contrib/reports/explore-server/src/client/CVEResultSummarization.tsx
+++ b/contrib/reports/explore-server/src/client/CVEResultSummarization.tsx
@@ -103,7 +103,8 @@ class OverviewTable extends React.Component<OverviewProps, OverviewState> {
                       a.toolID === t &&
                       row.commit.commitID === a.commit.commitID &&
                       row.file === a.file &&
-                      a.lines.some(line => row.line === line)
+                      row.line >= a.lineStart &&
+                      row.line <= a.lineEnd
                   )}
                   hasRun={(self.props.toolRuns[t] || []).includes(
                     this.props.unpatchedCommit.commitID
@@ -129,7 +130,8 @@ class OverviewTable extends React.Component<OverviewProps, OverviewState> {
             ta =>
               ta.toolID === t &&
               ta.isOnTarget &&
-              ta.lines.some(line => w.line === line) &&
+              w.line >= ta.lineStart &&
+              w.line <= ta.lineEnd &&
               w.file === ta.file
           ))
       );

--- a/contrib/reports/explore-server/src/client/CVEResults.tsx
+++ b/contrib/reports/explore-server/src/client/CVEResults.tsx
@@ -4,21 +4,24 @@ import * as MyCodeMirrors from "./MyCodeMirrors";
 import { cachingJSONFetch, cachingTextFetch, mkSimpleURL } from "./util";
 import { Alert, CommitData, Weakness } from "../shared/shared-types";
 
-function byLineSorter<T extends Weakness | Alert>(a1: T, a2: T) {
+function byLineAlertSorter(a1: Alert, a2: Alert) {
   // this line-sorting is apparently important for CodeMirror performance
-  let cmp = a1.line - a2.line;
+  let cmp = a1.lines[0] - a2.lines[0];
   if (cmp !== 0) {
     return cmp;
   }
-  let ruleCompare = (a1 as Alert).ruleID?.localeCompare?.((a2 as Alert).ruleID);
-  return (
-    ruleCompare ??
-    (a1 as Weakness).explanation?.localeCompare?.(
-      (a2 as Weakness).explanation
-    ) ??
-    0
-  );
+  return a1.ruleID.localeCompare(a2.ruleID);
 }
+
+function byLineWeaknessSorter(w1: Weakness, w2: Weakness) {
+  // this line-sorting is apparently important for CodeMirror performance
+  let cmp = w1.line - w2.line;
+  if (cmp !== 0) {
+    return cmp;
+  }
+  return w1.explanation.localeCompare(w2.explanation);
+}
+
 async function getSortedAlerts(cve: string) {
   let alerts: Alert[] = (
     await cachingJSONFetch(
@@ -27,7 +30,7 @@ async function getSortedAlerts(cve: string) {
       })
     )
   ).json;
-  return alerts.sort(byLineSorter);
+  return alerts.sort(byLineAlertSorter);
 }
 async function getSortedWeaknesses(cve: string) {
   let weaknesses: Weakness[] = (
@@ -37,7 +40,7 @@ async function getSortedWeaknesses(cve: string) {
       })
     )
   ).json;
-  return weaknesses.sort(byLineSorter);
+  return weaknesses.sort(byLineWeaknessSorter);
 }
 
 // TODO reformulate data entirely? Rely on the stable BCVE type instead?

--- a/contrib/reports/explore-server/src/client/CVEResults.tsx
+++ b/contrib/reports/explore-server/src/client/CVEResults.tsx
@@ -6,7 +6,11 @@ import { Alert, CommitData, Weakness } from "../shared/shared-types";
 
 function byLineAlertSorter(a1: Alert, a2: Alert) {
   // this line-sorting is apparently important for CodeMirror performance
-  let cmp = a1.lines[0] - a2.lines[0];
+  let cmp = a1.lineStart - a2.lineStart;
+  if (cmp !== 0) {
+    return cmp;
+  }
+  cmp = a1.lineEnd - a2.lineEnd;
   if (cmp !== 0) {
     return cmp;
   }

--- a/contrib/reports/explore-server/src/client/Conclusions.tsx
+++ b/contrib/reports/explore-server/src/client/Conclusions.tsx
@@ -310,6 +310,42 @@ export namespace Detection {
     setSourceFocus: SetSourceFocus;
   };
 
+  export function ShortExplanation(props: {
+    toolID: string;
+    hits: Alert[];
+    weaknesses: Weakness[];
+    unpatchedCommit: CommitData;
+  }) {
+    // TODO unify this with RecognitionConclusion (currently 50% duplication)
+    let hitCount = countAlertLocations(props.hits);
+    let detected = hitCount > 0;
+    let detectionSummary: React.ReactNode, hitsSummary: React.ReactNode;
+    if (detected) {
+      detectionSummary = (
+        <span className="tool-summary weakness-detected">
+          detected this CVE
+        </span>
+      );
+      hitsSummary = (
+        <span>
+          (flagging {hitCount} out of {countWeaknessLocations(props.weaknesses)}{" "}
+          weaknesses in {mkCommitUrl(props.unpatchedCommit)})
+        </span>
+      );
+    } else {
+      detectionSummary = (
+        <span className="tool-summary weakness-not-detected">
+          did not detect this CVE
+        </span>
+      );
+    }
+    return (
+      <>
+        {mkToolIDString(props.toolID)} {detectionSummary} {hitsSummary}.
+      </>
+    );
+  }
+
   export class DetailedExplanation extends React.Component<Props> {
     render() {
       let props = this.props;
@@ -321,7 +357,7 @@ export namespace Detection {
                 toolID={props.toolID}
                 weakness={w}
                 alerts={props.alerts.filter(
-                  a => a.file === w.file && a.lines.some(line => line === w.line)
+                  a => a.file === w.file && a.lineStart <= w.line && a.lineEnd >= w.line
                 )}
                 setSourceFocus={props.setSourceFocus}
               />

--- a/contrib/reports/explore-server/src/client/Conclusions.tsx
+++ b/contrib/reports/explore-server/src/client/Conclusions.tsx
@@ -4,7 +4,8 @@ import CompactLocationURL from "./CompactLocationURL";
 import { Alert, CommitData, Weakness } from "../shared/shared-types";
 import {
   AlertCountComparison,
-  countLocations,
+  countAlertLocations,
+  countWeaknessLocations,
   icons,
   mkCommitUrl,
   mkRuleListSentence,
@@ -309,42 +310,6 @@ export namespace Detection {
     setSourceFocus: SetSourceFocus;
   };
 
-  export function ShortExplanation(props: {
-    toolID: string;
-    hits: Alert[];
-    weaknesses: Weakness[];
-    unpatchedCommit: CommitData;
-  }) {
-    // TODO unify this with RecognitionConclusion (currently 50% duplication)
-    let hitCount = countLocations(props.hits);
-    let detected = hitCount > 0;
-    let detectionSummary: React.ReactNode, hitsSummary: React.ReactNode;
-    if (detected) {
-      detectionSummary = (
-        <span className="tool-summary weakness-detected">
-          detected this CVE
-        </span>
-      );
-      hitsSummary = (
-        <span>
-          (flagging {hitCount} out of {countLocations(props.weaknesses)}{" "}
-          weaknesses in {mkCommitUrl(props.unpatchedCommit)})
-        </span>
-      );
-    } else {
-      detectionSummary = (
-        <span className="tool-summary weakness-not-detected">
-          did not detect this CVE
-        </span>
-      );
-    }
-    return (
-      <>
-        {mkToolIDString(props.toolID)} {detectionSummary} {hitsSummary}.
-      </>
-    );
-  }
-
   export class DetailedExplanation extends React.Component<Props> {
     render() {
       let props = this.props;
@@ -356,7 +321,7 @@ export namespace Detection {
                 toolID={props.toolID}
                 weakness={w}
                 alerts={props.alerts.filter(
-                  a => a.file === w.file && a.line === w.line
+                  a => a.file === w.file && a.lines.some(line => line === w.line)
                 )}
                 setSourceFocus={props.setSourceFocus}
               />
@@ -435,8 +400,8 @@ export namespace Recognition {
           );
           hitsSummary = (
             <span>
-              (flagging {countLocations(props.hits)} out of{" "}
-              {countLocations(props.weaknesses)} weakness locations in{" "}
+              (flagging {countAlertLocations(props.hits)} out of{" "}
+              {countWeaknessLocations(props.weaknesses)} weakness locations in{" "}
               {mkCommitUrl(props.unpatchedCommit)})
             </span>
           );

--- a/contrib/reports/explore-server/src/client/MyCodeMirrors.tsx
+++ b/contrib/reports/explore-server/src/client/MyCodeMirrors.tsx
@@ -4,8 +4,7 @@ import * as ReactCodeMirror from "react-codemirror2";
 import * as ReactDOM from "react-dom";
 import * as Conclusions from "./Conclusions";
 import { Alert, Weakness } from "../shared/shared-types";
-import { getToolIcon, getToolOrderID } from "./util";
-import { rangeToArray } from "../../../../../src/util";
+import { getToolIcon, getToolOrderID, rangeToArray } from "./util";
 
 require("codemirror/mode/javascript/javascript");
 

--- a/contrib/reports/explore-server/src/client/MyCodeMirrors.tsx
+++ b/contrib/reports/explore-server/src/client/MyCodeMirrors.tsx
@@ -73,15 +73,15 @@ class AnnotatedCodeMirror extends React.Component<Props> {
           alerts: Alert[];
         };
       } = {};
-      self.props.gutterAnnotations.forEach(a => {
-        let key = `line:${a.line},toolID:${a.toolID}`;
+      self.props.gutterAnnotations.forEach(a => a.lines.forEach(line => {
+        let key = `line:${line},toolID:${a.toolID}`;
         alertsByLineAndToolId[key] = alertsByLineAndToolId[key] || {
-          line: a.line,
+          line: line,
           toolID: a.toolID,
           alerts: []
         };
         alertsByLineAndToolId[key].alerts.push(a);
-      });
+      }));
       for (let a of Object.values(alertsByLineAndToolId)) {
         e.setGutterMarker(
           a.line - 1,

--- a/contrib/reports/explore-server/src/client/MyCodeMirrors.tsx
+++ b/contrib/reports/explore-server/src/client/MyCodeMirrors.tsx
@@ -5,6 +5,8 @@ import * as ReactDOM from "react-dom";
 import * as Conclusions from "./Conclusions";
 import { Alert, Weakness } from "../shared/shared-types";
 import { getToolIcon, getToolOrderID } from "./util";
+import { rangeToArray } from "../../../../../src/util";
+
 require("codemirror/mode/javascript/javascript");
 
 type Props = {
@@ -73,7 +75,7 @@ class AnnotatedCodeMirror extends React.Component<Props> {
           alerts: Alert[];
         };
       } = {};
-      self.props.gutterAnnotations.forEach(a => a.lines.forEach(line => {
+      self.props.gutterAnnotations.forEach(a => rangeToArray(a.lineStart, a.lineEnd).forEach(line => {
         let key = `line:${line},toolID:${a.toolID}`;
         alertsByLineAndToolId[key] = alertsByLineAndToolId[key] || {
           line: line,

--- a/contrib/reports/explore-server/src/client/util.tsx
+++ b/contrib/reports/explore-server/src/client/util.tsx
@@ -45,6 +45,14 @@ export function groupAlertsByTool(alerts: Alert[], toolIDs: string[]) {
   }));
 }
 
+export function rangeToArray(start: number, end: number): number[] {
+  let result = [];
+  for (let i = start; i <= end; i++) {
+    result.push(i);
+  }
+  return result;
+}
+
 export function makeToolColumnKey(toolID: string) {
   return "tool-column-for-" + toolID;
 }

--- a/contrib/reports/explore-server/src/client/util.tsx
+++ b/contrib/reports/explore-server/src/client/util.tsx
@@ -158,10 +158,10 @@ export function getRelevantRuleAlertCounts(
         after: 0
       };
       if (a.commit.commitID === unpatchedCommit) {
-        relevantRuleAlertsMap[a.ruleID].before+=a.lines.length;
+        relevantRuleAlertsMap[a.ruleID].before++;
       }
       if (a.commit.commitID === patchedCommit) {
-        relevantRuleAlertsMap[a.ruleID].after+=a.lines.length;
+        relevantRuleAlertsMap[a.ruleID].after++;
       }
     });
   return Object.values(relevantRuleAlertsMap);
@@ -243,7 +243,7 @@ export function countWeaknessLocations(es: Weakness[]): number {
   return new Set(es.map(e => `${e.file}:${e.line}`)).size;
 }
 export function countAlertLocations(es: Alert[]): number {
-  return new Set(es.flatMap(e => e.lines.map(line => `${e.file}:${line}`))).size;
+  return new Set(es.map(e => `${e.file}:${e.lineStart}-${e.lineEnd}`)).size;
 }
 
 // Outputs whole number percentages that sum to 100.

--- a/contrib/reports/explore-server/src/client/util.tsx
+++ b/contrib/reports/explore-server/src/client/util.tsx
@@ -158,10 +158,10 @@ export function getRelevantRuleAlertCounts(
         after: 0
       };
       if (a.commit.commitID === unpatchedCommit) {
-        relevantRuleAlertsMap[a.ruleID].before++;
+        relevantRuleAlertsMap[a.ruleID].before+=a.lines.length;
       }
       if (a.commit.commitID === patchedCommit) {
-        relevantRuleAlertsMap[a.ruleID].after++;
+        relevantRuleAlertsMap[a.ruleID].after+=a.lines.length;
       }
     });
   return Object.values(relevantRuleAlertsMap);
@@ -239,8 +239,11 @@ export function getCve2tool2commitRuns(
   });
   return mapped;
 }
-export function countLocations(es: (Alert | Weakness)[]): number {
+export function countWeaknessLocations(es: Weakness[]): number {
   return new Set(es.map(e => `${e.file}:${e.line}`)).size;
+}
+export function countAlertLocations(es: Alert[]): number {
+  return new Set(es.flatMap(e => e.lines.map(line => `${e.file}:${line}`))).size;
 }
 
 // Outputs whole number percentages that sum to 100.

--- a/contrib/reports/explore-server/src/server/index.ts
+++ b/contrib/reports/explore-server/src/server/index.ts
@@ -13,7 +13,6 @@ import {
   CWEString
 } from "../../../../../src/persistent-types";
 import * as ClientTypes from "../shared/shared-types";
-import { rangeToArray } from "../../../../../src/util";
 
 function makePermalink(repository: string, commit: CommitID) {
   let githubRepoPattern = /^https:\/\/github.com\/([^/]+)\/([^/]+)\.git$/;

--- a/contrib/reports/explore-server/src/server/index.ts
+++ b/contrib/reports/explore-server/src/server/index.ts
@@ -13,6 +13,8 @@ import {
   CWEString
 } from "../../../../../src/persistent-types";
 import * as ClientTypes from "../shared/shared-types";
+import { rangeToArray } from "../../../../../src/util";
+
 function makePermalink(repository: string, commit: CommitID) {
   let githubRepoPattern = /^https:\/\/github.com\/([^/]+)\/([^/]+)\.git$/;
   let github = repository.match(githubRepoPattern);
@@ -84,13 +86,14 @@ function buildRulesOnATargetMap(
         .filter(
           a =>
             a.location &&
-            a.location.lines.some(line => isOnTarget(
+            isOnTarget(
               bcve.CVE,
               bcve.prePatch.commit,
               a.location.file,
-              line,
+              a.location.lineStart,
+              a.location.lineEnd,
               targets
-            ))
+            )
         )
         .map(a => ({
           CVE: bcve.CVE,
@@ -120,10 +123,12 @@ function isOnTarget(
   cve: CVEString,
   commit: CommitID,
   file: File,
-  line: number,
+  lineStart: number,
+  lineEnd: number,
   targets: TargetsMap
 ): boolean {
-  return !!targets.get(cve)?.get(commit)?.get(file)?.has(line);
+  let targetLines = [...(targets.get(cve)?.get(commit)?.get(file) || [])];
+  return targetLines.some(line => lineStart <= line && line <= lineEnd);
 }
 
 function isForRuleOnATarget(
@@ -240,16 +245,18 @@ export default class ExploreServer {
               commitDescription
             ),
             file: a.location.file,
-            lines: a.location.lines,
+            lineStart: a.location.lineStart,
+            lineEnd: a.location.lineEnd,
             toolID: r.toolID,
             ruleID: a.ruleID,
-            isOnTarget: a.location.lines.some(line => isOnTarget(
+            isOnTarget: isOnTarget(
               bcve.CVE,
               commitDescription.commit,
               a.location.file,
-              line,
+              a.location.lineStart,
+              a.location.lineEnd,
               targets
-            )),
+            ),
             isForRuleOnATarget: isForRuleOnATarget(
               bcve.CVE,
               r.toolID,

--- a/contrib/reports/explore-server/src/server/index.ts
+++ b/contrib/reports/explore-server/src/server/index.ts
@@ -84,13 +84,13 @@ function buildRulesOnATargetMap(
         .filter(
           a =>
             a.location &&
-            isOnTarget(
+            a.location.lines.some(line => isOnTarget(
               bcve.CVE,
               bcve.prePatch.commit,
               a.location.file,
-              a.location.line,
+              line,
               targets
-            )
+            ))
         )
         .map(a => ({
           CVE: bcve.CVE,
@@ -240,16 +240,16 @@ export default class ExploreServer {
               commitDescription
             ),
             file: a.location.file,
-            line: a.location.line,
+            lines: a.location.lines,
             toolID: r.toolID,
             ruleID: a.ruleID,
-            isOnTarget: isOnTarget(
+            isOnTarget: a.location.lines.some(line => isOnTarget(
               bcve.CVE,
               commitDescription.commit,
               a.location.file,
-              a.location.line,
+              line,
               targets
-            ),
+            )),
             isForRuleOnATarget: isForRuleOnATarget(
               bcve.CVE,
               r.toolID,

--- a/contrib/reports/explore-server/src/shared/shared-types.ts
+++ b/contrib/reports/explore-server/src/shared/shared-types.ts
@@ -17,7 +17,8 @@ export type Alert = {
   CVE: string;
   commit: CommitData;
   file: string;
-  lines: number[];
+  lineStart: number;
+  lineEnd: number;
   toolID: string;
   ruleID: string;
   isOnTarget: boolean;

--- a/contrib/reports/explore-server/src/shared/shared-types.ts
+++ b/contrib/reports/explore-server/src/shared/shared-types.ts
@@ -17,7 +17,7 @@ export type Alert = {
   CVE: string;
   commit: CommitData;
   file: string;
-  line: number;
+  lines: number[];
   toolID: string;
   ruleID: string;
   isOnTarget: boolean;

--- a/contrib/reports/flat-files/src/index.ts
+++ b/contrib/reports/flat-files/src/index.ts
@@ -30,7 +30,8 @@ function getClassification(alert: BCVEAlert, weaknesses: Weakness[]) {
   let classification = (weaknesses || []).some(
     w =>
       w.location.file === alert.location.file &&
-      alert.location.lines.some(line => w.location.line === line)
+      w.location.line >= alert.location.lineStart &&
+      w.location.line <= alert.location.lineEnd
   )
     ? AlertClassification.TP
     : AlertClassification.UNKNOWN;

--- a/contrib/reports/flat-files/src/index.ts
+++ b/contrib/reports/flat-files/src/index.ts
@@ -30,7 +30,7 @@ function getClassification(alert: BCVEAlert, weaknesses: Weakness[]) {
   let classification = (weaknesses || []).some(
     w =>
       w.location.file === alert.location.file &&
-      w.location.line === alert.location.line
+      alert.location.lines.some(line => w.location.line === line)
   )
     ? AlertClassification.TP
     : AlertClassification.UNKNOWN;

--- a/contrib/tools/codeql/src/codeql.ts
+++ b/contrib/tools/codeql/src/codeql.ts
@@ -21,7 +21,7 @@ import {
   File,
   RuleID
 } from "../../../../src/persistent-types";
-import {rangeToArray, readJSONFile} from "../../../../src/util";
+import { readJSONFile } from "../../../../src/util";
 
 type CodeQLMetaData = {
   kind: string;
@@ -275,12 +275,13 @@ function analyzeWithDriver(
     setAlerts(
       sarif.runs[0].results.map(
         (r: sarif.Result): BCVEAlert => {
-          let loc = getAlertLocation(r),
-            file = loc.artifactLocation.uri,
-            lines = rangeToArray(loc.region.startLine, loc.region.endLine),
-            location = { file, lines };
+          let loc = getAlertLocation(r);
           return {
-            location,
+            location: {
+              file: loc.artifactLocation.uri,
+              lineStart: loc.region.startLine,
+              lineEnd: loc.region.endLine
+            },
             ruleID: r.ruleId
           };
         }

--- a/contrib/tools/codeql/src/codeql.ts
+++ b/contrib/tools/codeql/src/codeql.ts
@@ -21,7 +21,7 @@ import {
   File,
   RuleID
 } from "../../../../src/persistent-types";
-import { readJSONFile } from "../../../../src/util";
+import {rangeToArray, readJSONFile} from "../../../../src/util";
 
 type CodeQLMetaData = {
   kind: string;
@@ -277,8 +277,8 @@ function analyzeWithDriver(
         (r: sarif.Result): BCVEAlert => {
           let loc = getAlertLocation(r),
             file = loc.artifactLocation.uri,
-            line = loc.region.startLine,
-            location = { file, line };
+            lines = rangeToArray(loc.region.startLine, loc.region.endLine),
+            location = { file, lines };
           return {
             location,
             ruleID: r.ruleId

--- a/contrib/tools/eslint/src/eslint.ts
+++ b/contrib/tools/eslint/src/eslint.ts
@@ -161,15 +161,25 @@ function convertEslintOutputToAlerts(
   type ESLintMessage = { ruleId: RuleID; line: number };
   type ESLintFileOutput = { filePath: File; messages: ESLintMessage[] };
   let eslintOutput: ESLintFileOutput[] = readJSONFile(eslintOutputFile);
-  return eslintOutput.flatMap((f: ESLintFileOutput): BCVEAlert[] =>
-    f.messages
-      .filter(m => !!m.ruleId /* parsing error */)
-      .map(m => ({
-        ruleID: m.ruleId,
-        location: {
-          file: path.relative(localSourceDirectory, f.filePath),
-          line: m.line
-        }
-      }))
+  let alertsMap: { [id: string]: {ruleId: string, lines: number[]} } = {};
+  let result: BCVEAlert[] = [];
+  eslintOutput.forEach((f: ESLintFileOutput) =>
+      f.messages
+          .filter(m => !!m.ruleId /* parsing error */)
+          .forEach(m => {
+              let filePath = path.relative(localSourceDirectory, f.filePath);
+              if (!alertsMap[filePath]) {
+                  alertsMap[filePath] = {ruleId: m.ruleId, lines: []};
+              }
+              alertsMap[filePath].lines.push(m.line);
+          })
   );
+  Object.keys(alertsMap).forEach(e => result.push({
+      ruleID: alertsMap[e].ruleId,
+      location: {
+          file: e,
+          lines: alertsMap[e].lines
+      }
+  }));
+  return result;
 }

--- a/contrib/tools/eslint/src/eslint.ts
+++ b/contrib/tools/eslint/src/eslint.ts
@@ -158,28 +158,19 @@ function convertEslintOutputToAlerts(
       }
       ... ]
   */
-  type ESLintMessage = { ruleId: RuleID; line: number };
+  type ESLintMessage = { ruleId: RuleID; line: number, endLine: number };
   type ESLintFileOutput = { filePath: File; messages: ESLintMessage[] };
   let eslintOutput: ESLintFileOutput[] = readJSONFile(eslintOutputFile);
-  let alertsMap: { [id: string]: {ruleId: string, lines: number[]} } = {};
-  let result: BCVEAlert[] = [];
-  eslintOutput.forEach((f: ESLintFileOutput) =>
-      f.messages
-          .filter(m => !!m.ruleId /* parsing error */)
-          .forEach(m => {
-              let filePath = path.relative(localSourceDirectory, f.filePath);
-              if (!alertsMap[filePath]) {
-                  alertsMap[filePath] = {ruleId: m.ruleId, lines: []};
-              }
-              alertsMap[filePath].lines.push(m.line);
-          })
+  return eslintOutput.flatMap((f: ESLintFileOutput): BCVEAlert[] =>
+    f.messages
+      .filter(m => !!m.ruleId /* parsing error */)
+      .map(m => ({
+        ruleID: m.ruleId,
+        location: {
+          file: path.relative(localSourceDirectory, f.filePath),
+          lineStart: m.line,
+          lineEnd: m.endLine,
+        }
+      }))
   );
-  Object.keys(alertsMap).forEach(e => result.push({
-      ruleID: alertsMap[e].ruleId,
-      location: {
-          file: e,
-          lines: alertsMap[e].lines
-      }
-  }));
-  return result;
 }

--- a/contrib/tools/ideal-analysis/src/ideal-analysis.ts
+++ b/contrib/tools/ideal-analysis/src/ideal-analysis.ts
@@ -13,7 +13,7 @@ drive(async function analyze({
   setAlerts(
     (commitDescription.weaknesses || []).map(w => ({
       ruleID: `rule-for-${bcve.CVE}`,
-      location: { file: w.location.file, line: w.location.line }
+      location: { file: w.location.file, lines: [w.location.line] }
     }))
   );
   setStatus(BCVEResultStatus.SUCCESS);

--- a/contrib/tools/ideal-analysis/src/ideal-analysis.ts
+++ b/contrib/tools/ideal-analysis/src/ideal-analysis.ts
@@ -13,7 +13,11 @@ drive(async function analyze({
   setAlerts(
     (commitDescription.weaknesses || []).map(w => ({
       ruleID: `rule-for-${bcve.CVE}`,
-      location: { file: w.location.file, lines: [w.location.line] }
+      location: {
+        file: w.location.file,
+        lineStart: w.location.line,
+        lineEnd: w.location.line
+      }
     }))
   );
   setStatus(BCVEResultStatus.SUCCESS);

--- a/schemas/ts-defs.schema.json
+++ b/schemas/ts-defs.schema.json
@@ -312,17 +312,19 @@
           "$ref": "#/definitions/File",
           "description": "The path to the file."
         },
-        "lines": {
-          "description": "The line numbers.",
-          "items": {
-            "type": "number"
-          },
-          "type": "array"
+        "lineStart": {
+          "description": "The starting line number.",
+          "type": "number"
+        },
+        "lineEnd": {
+          "description": "The ending line number.",
+          "type": "number"
         }
       },
       "required": [
         "file",
-        "lines"
+        "lineStart",
+        "lineEnd"
       ],
       "title": "SourceLocation",
       "type": "object"

--- a/schemas/ts-defs.schema.json
+++ b/schemas/ts-defs.schema.json
@@ -312,14 +312,17 @@
           "$ref": "#/definitions/File",
           "description": "The path to the file."
         },
-        "line": {
-          "description": "The line number.",
-          "type": "number"
+        "lines": {
+          "description": "The line numbers.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
         }
       },
       "required": [
         "file",
-        "line"
+        "lines"
       ],
       "title": "SourceLocation",
       "type": "object"

--- a/src/persistent-types.ts
+++ b/src/persistent-types.ts
@@ -26,9 +26,13 @@ export type SourceLocation = {
    */
   file: File;
   /**
-   * The line number.
+   * The starting line number.
    */
-  lines: number[];
+  lineStart: number;
+  /**
+   * The ending line number.
+   */
+  lineEnd: number;
 };
 
 /**

--- a/src/persistent-types.ts
+++ b/src/persistent-types.ts
@@ -28,7 +28,7 @@ export type SourceLocation = {
   /**
    * The line number.
    */
-  line: number;
+  lines: number[];
 };
 
 /**
@@ -40,7 +40,15 @@ export type Weakness = {
   /**
    * The source location of the weakness, relative to the root of the vulnerable project
    */
-  location: SourceLocation & {
+  location: {
+    /**
+     * The path to the file.
+     */
+    file: File;
+    /**
+     * The line number.
+     */
+    line: number;
     /**
      * The implicit file extension of `file`, e.g. 'js' or 'sh'
      */

--- a/src/util.ts
+++ b/src/util.ts
@@ -364,14 +364,6 @@ export function spawnChildProcess(
   });
 }
 
-export function rangeToArray(start: number, end: number): number[] {
-  let result = [];
-  for (let i = start; i <= end; i++) {
-    result.push(i);
-  }
-  return result;
-}
-
 export function convertSarifLogToAlerts(log: sarif.Log): BCVEAlert[] {
   return log.runs.flatMap(run =>
     run.results.map((r: sarif.Result): BCVEAlert => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -364,14 +364,22 @@ export function spawnChildProcess(
   });
 }
 
+export function rangeToArray(start: number, end: number): number[] {
+  let result = [];
+  for (let i = start; i < end; i += 1) {
+    result.push(i);
+  }
+  return result;
+}
+
 export function convertSarifLogToAlerts(log: sarif.Log): BCVEAlert[] {
   return log.runs.flatMap(run =>
     run.results.map(
       (r: sarif.Result): BCVEAlert => {
         let loc = r.locations[0].physicalLocation,
           file = loc.artifactLocation.uri,
-          line = loc.region.startLine,
-          location = { file, line };
+          lines = rangeToArray(loc.region.startLine, loc.region.endLine),
+          location = { file, lines };
         return {
           location,
           ruleID: r.ruleId

--- a/src/util.ts
+++ b/src/util.ts
@@ -366,7 +366,7 @@ export function spawnChildProcess(
 
 export function rangeToArray(start: number, end: number): number[] {
   let result = [];
-  for (let i = start; i < end; i += 1) {
+  for (let i = start; i <= end; i++) {
     result.push(i);
   }
   return result;
@@ -374,18 +374,17 @@ export function rangeToArray(start: number, end: number): number[] {
 
 export function convertSarifLogToAlerts(log: sarif.Log): BCVEAlert[] {
   return log.runs.flatMap(run =>
-    run.results.map(
-      (r: sarif.Result): BCVEAlert => {
-        let loc = r.locations[0].physicalLocation,
-          file = loc.artifactLocation.uri,
-          lines = rangeToArray(loc.region.startLine, loc.region.endLine),
-          location = { file, lines };
-        return {
-          location,
-          ruleID: r.ruleId
-        };
-      }
-    )
+    run.results.map((r: sarif.Result): BCVEAlert => {
+      let loc = r.locations[0].physicalLocation;
+      return {
+        location: {
+          file: loc.artifactLocation.uri,
+          lineStart: loc.region.startLine,
+          lineEnd: loc.region.endLine
+        },
+        ruleID: r.ruleId
+      };
+    })
   );
 }
 


### PR DESCRIPTION
I'm using this framework to compare AI driven tools vs static, or other AI tools. Usually, these AI tools generate a lot more alert, than static tools, which the current architecture could not handle (I've managed to exceed the maximum string lenght limit, where the reporting server tries to send the results data to the client in JSON format). I've overcame this problem by slightly changing the alert storing format from one line per Alert (here Alert with big A is the so-called data type in the framework), to multiple lines in one Alert.

This change does not modify anything in the behavior of the framework, only makes it possible to be used on a vast amount of data (also can be useful later in case a lot more static tools will be added to the contributions folder).